### PR TITLE
The instructions for generating the DHPARAM didn't create the file, I

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ Trying to use a feature requiring a disabled microservice will result in an erro
 #### Generating Diffie-Hellman parameters
 
 ```bash
-openssl dhparam 4096 -outform PEM -out dh4096.pem
+openssl dhparam -outform PEM -out dh4096.pem 4096
 ```
 
 #### Generating a self-signed Certification Authority (CA)


### PR DESCRIPTION
looked at the man page for openssl-dhparam and it says to put the number
of bits at the end of the command.  Doing so, it worked for me.